### PR TITLE
Fix incompatibility with openfortivpn >= 1.11.0

### DIFF
--- a/src/nm-fortisslvpn-service.c
+++ b/src/nm-fortisslvpn-service.c
@@ -229,6 +229,7 @@ run_openfortivpn (NMFortisslvpnPlugin *plugin, NMSettingVpn *s_vpn, GError **err
 
 	g_ptr_array_add (argv, (gpointer) g_strdup ("--no-routes"));
 	g_ptr_array_add (argv, (gpointer) g_strdup ("--no-dns"));
+	g_ptr_array_add (argv, (gpointer) g_strdup ("--pppd-use-peerdns=1"));
 
 	value = nm_setting_vpn_get_data_item (s_vpn, NM_FORTISSLVPN_KEY_GATEWAY);
 	g_ptr_array_add (argv, (gpointer) g_strdup (value));


### PR DESCRIPTION
Before _openfortipvn_ 1.11.0 the default configuration was equivalent to:
	`--set-dns=1 --pppd-use-peerdns=1`
Starting with _openfortivpn_ 1.11.0 the default configuration is equivalent to:
        `--set-dns=1 --pppd-use-peerdns=0`

_NetworkManager-fortisslvpn_ expects the configuration to be equivalent to:
	`--set-dns=0 --pppd-use-peerdns=1`
This expectation breaks with _openfortivpn_ 1.11.0 because _NetworkManager-fortisslvpn_ only passes this command line option:
	`--no-dns` / `--set-dns=0`
Starting with _openfortivpn_ 1.11.0 it needs to be:
	`--no-dns` / `--set-dns=0` `--pppd-use-peerdns=1`

This patch adds `--pppd-use-peerdns=1` as is already the case in _Fedora_ packages:
https://src.fedoraproject.org/rpms/NetworkManager-fortisslvpn/c/6378487

I realize that this patch breaks compatibility with early _openfortivpn_ versions that don't have option `--pppd-use-peerdns`. That's unfortunate and I'm sorry about that. I cannot think about another solution though.

This is also explained here:
https://github.com/adrienverge/openfortivpn/issues/503